### PR TITLE
Fix weekly chart bar height types

### DIFF
--- a/lib/reports_screen.dart
+++ b/lib/reports_screen.dart
@@ -91,9 +91,9 @@ class _ReportsScreenState extends State<ReportsScreen> {
                       padding: const EdgeInsets.symmetric(horizontal: 4),
                       child: Container(
                         height: (_habits.isEmpty
-                                ? 0
+                                ? 0.0
                                 : (_dailyTotals[i] / _habits.length) * 100)
-                            .clamp(0, 100),
+                            .clamp(0.0, 100.0),
                         color: Colors.blueAccent,
                       ),
                     ),


### PR DESCRIPTION
## Summary
- fix clamp parameter types for weekly report chart bars

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd9a8e4a4832ca5531e463fab1c78