### PR TITLE
Fix age label in Profile screen

### DIFF
--- a/lib/profile_screen.dart
+++ b/lib/profile_screen.dart
@@ -77,7 +77,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
             ),
             const SizedBox(height: 16),
             Text(
-              'Age: \${_age.round()}',
+              'Age: ${_age.round()}',
               style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
             ),
             Slider(


### PR DESCRIPTION
## Summary
- fix string interpolation for Age label on the Profile screen

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fe6453a48832cb0550b01a8a0db1e