### PR TITLE
Add Habit Info screen

### DIFF
--- a/lib/habit_detail_screen.dart
+++ b/lib/habit_detail_screen.dart
@@ -1,0 +1,168 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'constants.dart';
+
+class HabitDetailScreen extends StatefulWidget {
+  final String habit;
+  const HabitDetailScreen({super.key, required this.habit});
+
+  @override
+  State<HabitDetailScreen> createState() => _HabitDetailScreenState();
+}
+
+class _HabitDetailScreenState extends State<HabitDetailScreen> {
+  Color _color = Colors.blue;
+  final TextEditingController _goalController = TextEditingController();
+  final Map<int, bool> _weekDone = {for (int i = 1; i <= 7; i++) i: false};
+  int _streak = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final colorData = prefs.getString('habit_colors');
+    if (colorData != null) {
+      final map = jsonDecode(colorData) as Map<String, dynamic>;
+      if (map.containsKey(widget.habit)) {
+        _color = Color(map[widget.habit] as int);
+      }
+    }
+    final goalData = prefs.getString('habit_goals');
+    if (goalData != null) {
+      final map = jsonDecode(goalData) as Map<String, dynamic>;
+      _goalController.text = map[widget.habit] ?? '';
+    }
+
+    final key = _habitKey(widget.habit);
+    final completed = prefs.getStringList(key) ?? [];
+    final now = DateTime.now();
+    // status for current week Mon-Sun
+    for (int i = 1; i <= 7; i++) {
+      final date = now.subtract(Duration(days: now.weekday - i));
+      final str = date.toIso8601String().split('T').first;
+      _weekDone[i] = completed.contains(str);
+    }
+    // streak calculation
+    var day = now;
+    while (completed.contains(day.toIso8601String().split('T').first)) {
+      _streak++;
+      day = day.subtract(const Duration(days: 1));
+    }
+    setState(() {});
+  }
+
+  String _habitKey(String h) => 'habit_${h.replaceAll(' ', '_')}';
+
+  Future<void> _pickColor() async {
+    final selected = await showDialog<Color>(
+      context: context,
+      builder: (_) {
+        return AlertDialog(
+          title: const Text('Select Color'),
+          content: Wrap(
+            spacing: 8,
+            children: habitColorPalette
+                .map(
+                  (c) => GestureDetector(
+                    onTap: () => Navigator.pop(context, c),
+                    child: CircleAvatar(backgroundColor: c, radius: 12),
+                  ),
+                )
+                .toList(),
+          ),
+        );
+      },
+    );
+    if (selected != null) {
+      setState(() => _color = selected);
+    }
+  }
+
+  Future<void> _save() async {
+    final prefs = await SharedPreferences.getInstance();
+    // save color
+    final colorData = prefs.getString('habit_colors');
+    final colorMap =
+        colorData != null ? Map<String, dynamic>.from(jsonDecode(colorData)) : {};
+    colorMap[widget.habit] = _color.value;
+    await prefs.setString('habit_colors', jsonEncode(colorMap));
+    // save goal
+    final goalData = prefs.getString('habit_goals');
+    final goalMap =
+        goalData != null ? Map<String, dynamic>.from(jsonDecode(goalData)) : {};
+    goalMap[widget.habit] = _goalController.text.trim();
+    await prefs.setString('habit_goals', jsonEncode(goalMap));
+    // save week status
+    final key = _habitKey(widget.habit);
+    final completed = prefs.getStringList(key) ?? [];
+    final now = DateTime.now();
+    for (int i = 1; i <= 7; i++) {
+      final date = now.subtract(Duration(days: now.weekday - i));
+      final str = date.toIso8601String().split('T').first;
+      final done = _weekDone[i] ?? false;
+      if (done && !completed.contains(str)) {
+        completed.add(str);
+      } else if (!done && completed.contains(str)) {
+        completed.remove(str);
+      }
+    }
+    await prefs.setStringList(key, completed);
+    if (!mounted) return;
+    Navigator.pop(context);
+  }
+
+  @override
+  void dispose() {
+    _goalController.dispose();
+    super.dispose();
+  }
+
+  String _weekdayLabel(int w) {
+    const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+    return days[w - 1];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Habit Info ${widget.habit}')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          ElevatedButton(onPressed: _pickColor, child: const Text('Select Color')),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _goalController,
+            decoration: const InputDecoration(labelText: 'Goal'),
+          ),
+          const SizedBox(height: 16),
+          Text('$_streak days in a row'),
+          const SizedBox(height: 16),
+          const Text('Weekdays'),
+          Wrap(
+            spacing: 8,
+            children: [
+              for (int i = 1; i <= 7; i++)
+                FilterChip(
+                  label: Text(_weekdayLabel(i)),
+                  selected: _weekDone[i] ?? false,
+                  onSelected: (v) => setState(() => _weekDone[i] = v),
+                  selectedColor: _color.withOpacity(0.2),
+                )
+            ],
+          ),
+          const SizedBox(height: 20),
+          ElevatedButton(onPressed: _save, child: const Text('Edit Habit')),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/habit_info_screen.dart
+++ b/lib/habit_info_screen.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'habit_detail_screen.dart';
+
+class HabitInfoScreen extends StatefulWidget {
+  const HabitInfoScreen({super.key});
+
+  @override
+  State<HabitInfoScreen> createState() => _HabitInfoScreenState();
+}
+
+class _HabitInfoScreenState extends State<HabitInfoScreen> {
+  List<String> _habits = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    setState(() {
+      _habits = prefs.getStringList('habits') ?? [];
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Habit Info')),
+      body: ListView(
+        children: _habits
+            .map(
+              (h) => ListTile(
+                title: Text(h),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () async {
+                  await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => HabitDetailScreen(habit: h)),
+                  );
+                  _load();
+                },
+              ),
+            )
+            .toList(),
+      ),
+    );
+  }
+}

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -9,6 +9,8 @@ import 'profile_screen.dart';
 import 'reports_screen.dart';
 import 'notifications_screen.dart';
 import 'constants.dart';
+import 'habit_detail_screen.dart';
+import 'habit_info_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -83,24 +85,35 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
+  Future<void> _openDetail(String habit) async {
+    await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => HabitDetailScreen(habit: habit)),
+    );
+    _loadData();
+  }
+
   Widget _buildTodoItem(String habit) {
     final color = _habitColors[habit] ?? habitColorPalette.first;
-    return Container(
-      margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 16),
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      decoration: BoxDecoration(
-        color: color.withOpacity(0.1),
-        borderRadius: BorderRadius.circular(20),
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          Text(habit),
-          IconButton(
-            icon: Icon(Icons.check_circle, color: color),
-            onPressed: () => _toggleHabit(habit, true),
-          ),
-        ],
+    return GestureDetector(
+      onTap: () => _openDetail(habit),
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 16),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: color.withOpacity(0.1),
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(habit),
+            IconButton(
+              icon: Icon(Icons.check_circle, color: color),
+              onPressed: () => _toggleHabit(habit, true),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -140,6 +153,16 @@ class _HomeScreenState extends State<HomeScreen> {
                   context,
                   MaterialPageRoute(builder: (_) => const ReportsScreen()),
                 );
+              },
+            ),
+            ListTile(
+              title: const Text('Habit Info'),
+              onTap: () async {
+                await Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const HabitInfoScreen()),
+                );
+                Navigator.pop(context);
               },
             ),
             ListTile(
@@ -213,19 +236,22 @@ class _HomeScreenState extends State<HomeScreen> {
                 else
                   ..._habits
                       .where((h) => _todayStatus[h] == true)
-                      .map((h) => Container(
-                            margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 16),
-                            padding: const EdgeInsets.all(8),
-                            decoration: BoxDecoration(
-                              color: Colors.yellow.shade100,
-                              borderRadius: BorderRadius.circular(8),
-                            ),
-                            child: Row(
-                              children: [
-                                Icon(Icons.star, color: _habitColors[h] ?? Colors.blue),
-                                const SizedBox(width: 8),
-                                Text(h),
-                              ],
+                      .map((h) => GestureDetector(
+                            onTap: () => _openDetail(h),
+                            child: Container(
+                              margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 16),
+                              padding: const EdgeInsets.all(8),
+                              decoration: BoxDecoration(
+                                color: Colors.yellow.shade100,
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              child: Row(
+                                children: [
+                                  Icon(Icons.star, color: _habitColors[h] ?? Colors.blue),
+                                  const SizedBox(width: 8),
+                                  Text(h),
+                                ],
+                              ),
                             ),
                           ))
                       .toList(),


### PR DESCRIPTION
## Summary
- create HabitDetailScreen and HabitInfoScreen
- show habit info and editing options
- allow tapping habits to open detail
- link Habit Info from drawer

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688004044998832c8b65119516bab001