### PR TITLE
Enhance habit info screen with creation flow

### DIFF
--- a/lib/habit_info_screen.dart
+++ b/lib/habit_info_screen.dart
@@ -1,6 +1,9 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'constants.dart';
 import 'habit_detail_screen.dart';
 
 class HabitInfoScreen extends StatefulWidget {
@@ -11,7 +14,11 @@ class HabitInfoScreen extends StatefulWidget {
 }
 
 class _HabitInfoScreenState extends State<HabitInfoScreen> {
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _goalController = TextEditingController();
   List<String> _habits = [];
+  final Map<String, Color> _habitColors = {};
+  Color _newColor = habitColorPalette.first;
 
   @override
   void initState() {
@@ -23,7 +30,79 @@ class _HabitInfoScreenState extends State<HabitInfoScreen> {
     final prefs = await SharedPreferences.getInstance();
     setState(() {
       _habits = prefs.getStringList('habits') ?? [];
+      final colorData = prefs.getString('habit_colors');
+      if (colorData != null) {
+        final map = jsonDecode(colorData) as Map<String, dynamic>;
+        _habitColors.clear();
+        map.forEach((k, v) => _habitColors[k] = Color(v as int));
+      }
     });
+  }
+
+  Future<Color?> _pickColor(Color current) {
+    return showDialog<Color>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Select color'),
+          content: Wrap(
+            spacing: 8,
+            children: habitColorPalette
+                .map(
+                  (c) => GestureDetector(
+                    onTap: () => Navigator.pop(context, c),
+                    child: CircleAvatar(backgroundColor: c, radius: 12),
+                  ),
+                )
+                .toList(),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _addHabit() async {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) return;
+    if (_habits.length >= maxHabits) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Maximum of $maxHabits habits allowed')),
+      );
+      return;
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    setState(() {
+      _habits.add(name);
+      _habitColors[name] = _newColor;
+    });
+    await prefs.setStringList('habits', _habits);
+    final map = _habitColors.map((k, v) => MapEntry(k, v.value));
+    await prefs.setString('habit_colors', jsonEncode(map));
+
+    final goal = _goalController.text.trim();
+    if (goal.isNotEmpty) {
+      final goalData = prefs.getString('habit_goals');
+      final goalMap =
+          goalData != null ? Map<String, dynamic>.from(jsonDecode(goalData)) : {};
+      goalMap[name] = goal;
+      await prefs.setString('habit_goals', jsonEncode(goalMap));
+    }
+
+    _nameController.clear();
+    _goalController.clear();
+    setState(() => _newColor = habitColorPalette.first);
+    _load();
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Added "$name"')),
+    );
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _goalController.dispose();
+    super.dispose();
   }
 
   @override
@@ -31,22 +110,54 @@ class _HabitInfoScreenState extends State<HabitInfoScreen> {
     return Scaffold(
       appBar: AppBar(title: const Text('Habit Info')),
       body: ListView(
-        children: _habits
-            .map(
-              (h) => ListTile(
-                title: Text(h),
-                trailing: const Icon(Icons.chevron_right),
+        padding: const EdgeInsets.all(8),
+        children: [
+          ..._habits
+              .map(
+                (h) => ListTile(
+                  title: Text(h),
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () async {
+                    await Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (_) => HabitDetailScreen(habit: h)),
+                    );
+                    _load();
+                  },
+                ),
+              )
+              .toList(),
+          const Divider(),
+          TextField(
+            controller: _nameController,
+            decoration: const InputDecoration(labelText: 'Habit name'),
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: _goalController,
+            decoration:
+                const InputDecoration(labelText: 'Goal (optional)'),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              GestureDetector(
                 onTap: () async {
-                  await Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                        builder: (_) => HabitDetailScreen(habit: h)),
-                  );
-                  _load();
+                  final sel = await _pickColor(_newColor);
+                  if (sel != null) setState(() => _newColor = sel);
                 },
+                child: CircleAvatar(backgroundColor: _newColor, radius: 12),
               ),
-            )
-            .toList(),
+              const SizedBox(width: 16),
+              ElevatedButton.icon(
+                onPressed: _addHabit,
+                icon: const Icon(Icons.add),
+                label: const Text('Add Habit'),
+              ),
+            ],
+          ),
+        ],
       ),
     );
   }

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import 'habits_screen.dart';
 import 'login_screen.dart';
 import 'profile_screen.dart';
 import 'reports_screen.dart';
@@ -136,17 +135,6 @@ class _HomeScreenState extends State<HomeScreen> {
               ),
             ),
             ListTile(
-              title: const Text('Habits'),
-              onTap: () async {
-                await Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (_) => const HabitsScreen()),
-                );
-                _loadData();
-                Navigator.pop(context);
-              },
-            ),
-            ListTile(
               title: const Text('Reports'),
               onTap: () {
                 Navigator.push(
@@ -219,7 +207,7 @@ class _HomeScreenState extends State<HomeScreen> {
                     onPressed: () async {
                       await Navigator.push(
                         context,
-                        MaterialPageRoute(builder: (_) => const HabitsScreen()),
+                        MaterialPageRoute(builder: (_) => const HabitInfoScreen()),
                       );
                       _loadData();
                     },


### PR DESCRIPTION
## Summary
- integrate add habit flow into Habit Info screen
- remove old Habits drawer link
- update Home screen Add button to open Habit Info screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688007d3dc04832ca92196b582267798