### PR TITLE
Fix imports in report screen

### DIFF
--- a/lib/reports_screen.dart
+++ b/lib/reports_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'constants.dart';
+
 class ReportsScreen extends StatefulWidget {
   const ReportsScreen({super.key});
 


### PR DESCRIPTION
## Summary
- fix missing import of habit color palette in ReportsScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68814b7ea6e4832ca9739602d13f7ebc