### PR TITLE
Fix habit sync and weekly reports

### DIFF
--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -157,6 +157,7 @@ class _HomeScreenState extends State<HomeScreen> {
                   MaterialPageRoute(builder: (_) => const HabitInfoScreen()),
                 );
                 Navigator.pop(context);
+                _loadData();
               },
             ),
             ListTile(


### PR DESCRIPTION
## Summary
- sync home screen habits after returning from Habit Info
- recalc weekly report data using last 7 days
- compute best day based on real data
- always render all seven bars in chart

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68814e14eb30832cb7b98377be8774da