### PR TITLE
Fix type error in reports screen

### DIFF
--- a/lib/reports_screen.dart
+++ b/lib/reports_screen.dart
@@ -106,7 +106,8 @@ class _ReportsScreenState extends State<ReportsScreen> {
                                 : max(
                                         (_dailyTotals[i] / _habits.length) * 100,
                                         4)
-                                    .clamp(0.0, 100.0),
+                                    .clamp(0.0, 100.0)
+                                    .toDouble(),
                             decoration: BoxDecoration(
                               color: _dailyTotals[i] == 0
                                   ? Colors.grey.shade300


### PR DESCRIPTION
## Summary
- fix num to double mismatch in bar height calculation

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688151085238832c8c12b80c07c1c7ed