### PR TITLE
Add vibrant pill UI for home and notifications

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -17,9 +17,9 @@ const int maxHabits = 10;
 
 /// Pastel backgrounds used throughout the UI.
 const List<Color> pastelBackgrounds = [
-  Color(0xFFE2E8FF),
-  Color(0xFFD1FAE5),
-  Color(0xFFFDE68A),
+  Color(0xFF80DEEA), // vibrant cyan
+  Color(0xFFFFE082), // vibrant amber
+  Color(0xFFA5D6A7), // vibrant green
 ];
 
 /// Predefined habits offered during registration and editing.

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -93,27 +93,36 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   Widget _buildHabitRow(String habit) {
-    final color = _habitColors[habit] ?? habitColorPalette.first;
-    final bg = pastelBackgrounds[_habits.indexOf(habit) % pastelBackgrounds.length];
+    final color = _habitColors[habit] ??
+        habitColorPalette[_habits.indexOf(habit) % habitColorPalette.length];
     final done = _todayStatus[habit] ?? false;
     return GestureDetector(
       onTap: () => _openDetail(habit),
       child: Container(
         margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 16),
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
         decoration: BoxDecoration(
-          color: bg,
-          borderRadius: BorderRadius.circular(20),
+          color: color,
+          borderRadius: BorderRadius.circular(30),
         ),
         child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Text(habit,
-                style: const TextStyle(fontWeight: FontWeight.w500, fontSize: 16)),
+            Expanded(
+              child: Center(
+                child: Text(
+                  habit,
+                  style: const TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 16,
+                    color: Colors.black,
+                  ),
+                ),
+              ),
+            ),
             IconButton(
               icon: Icon(
                 done ? Icons.star : Icons.star_border,
-                color: done ? Colors.amber : Colors.grey,
+                color: done ? Colors.yellow.shade700 : Colors.black54,
               ),
               onPressed: () => _toggleHabit(habit, !done),
             ),
@@ -127,6 +136,7 @@ class _HomeScreenState extends State<HomeScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        backgroundColor: Colors.orangeAccent,
         title: const Text('Home'),
       ),
       drawer: Drawer(
@@ -204,17 +214,15 @@ class _HomeScreenState extends State<HomeScreen> {
                         fontSize: 24, fontWeight: FontWeight.bold),
                   ),
                 ),
-                Container(
-                  margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                  padding: const EdgeInsets.all(8),
-                  decoration: BoxDecoration(
-                    color: pastelBackgrounds[1],
-                    borderRadius: BorderRadius.circular(12),
-                  ),
+                Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
                   child: const Text(
                     'To Do',
-                    style:
-                        TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+                    style: TextStyle(
+                        fontSize: 20,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.orange),
                   ),
                 ),
                 if (_habits.where((h) => !(_todayStatus[h] ?? false)).isEmpty)
@@ -225,36 +233,31 @@ class _HomeScreenState extends State<HomeScreen> {
                       .map(_buildHabitRow)
                       .toList(),
                 Center(
-                  child: Container(
-                    decoration: BoxDecoration(
-                      color: pastelBackgrounds[0],
-                      borderRadius: BorderRadius.circular(30),
+                  child: ElevatedButton(
+                    onPressed: () async {
+                      await Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (_) => const HabitInfoScreen()),
+                      );
+                      _loadData();
+                    },
+                    style: ElevatedButton.styleFrom(
+                      shape: const CircleBorder(),
+                      padding: const EdgeInsets.all(16),
+                      backgroundColor: Colors.orangeAccent,
                     ),
-                    child: ElevatedButton.icon(
-                      onPressed: () async {
-                        await Navigator.push(
-                          context,
-                          MaterialPageRoute(builder: (_) => const HabitInfoScreen()),
-                        );
-                        _loadData();
-                      },
-                      icon: const Icon(Icons.add),
-                      label: const Text('Add'),
-                      style: ElevatedButton.styleFrom(shape: const StadiumBorder()),
-                    ),
+                    child: const Icon(Icons.add, color: Colors.white),
                   ),
                 ),
-                Container(
-                  margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                  padding: const EdgeInsets.all(8),
-                  decoration: BoxDecoration(
-                    color: pastelBackgrounds[2],
-                    borderRadius: BorderRadius.circular(12),
-                  ),
+                Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
                   child: const Text(
                     'Completed Today',
-                    style:
-                        TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+                    style: TextStyle(
+                        fontSize: 20,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.orange),
                   ),
                 ),
                 if (_habits.where((h) => _todayStatus[h] == true).isEmpty)

--- a/lib/notifications_screen.dart
+++ b/lib/notifications_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'constants.dart';
 
 class NotificationsScreen extends StatefulWidget {
   const NotificationsScreen({super.key});
@@ -67,56 +68,137 @@ class _NotificationsScreenState extends State<NotificationsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Notifications')),
+      appBar: AppBar(
+        title: const Text('Notifications'),
+        backgroundColor: Colors.purpleAccent,
+      ),
+      backgroundColor: pastelBackgrounds.first,
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
-          SwitchListTile(
-            title: const Text('Enable Notifications'),
-            value: _enabled,
-            onChanged: (v) => setState(() => _enabled = v),
+          Container(
+            margin: const EdgeInsets.symmetric(vertical: 6),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: SwitchListTile(
+              title: const Text(
+                'Enable Notifications',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              value: _enabled,
+              onChanged: (v) => setState(() => _enabled = v),
+            ),
           ),
-          SwitchListTile(
-            title: const Text('Daily reminder'),
-            value: _dailyReminder,
-            onChanged: (v) => setState(() => _dailyReminder = v),
+          Container(
+            margin: const EdgeInsets.symmetric(vertical: 6),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: SwitchListTile(
+              title: const Text(
+                'Daily reminder',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              value: _dailyReminder,
+              onChanged: (v) => setState(() => _dailyReminder = v),
+            ),
           ),
-          SwitchListTile(
-            title: const Text('Streak Alerts'),
-            value: _streakAlerts,
-            onChanged: (v) => setState(() => _streakAlerts = v),
+          Container(
+            margin: const EdgeInsets.symmetric(vertical: 6),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: SwitchListTile(
+              title: const Text(
+                'Streak Alerts',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              value: _streakAlerts,
+              onChanged: (v) => setState(() => _streakAlerts = v),
+            ),
           ),
-          SwitchListTile(
-            title: const Text('Goal missed'),
-            value: _goalMissed,
-            onChanged: (v) => setState(() => _goalMissed = v),
+          Container(
+            margin: const EdgeInsets.symmetric(vertical: 6),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: SwitchListTile(
+              title: const Text(
+                'Goal missed',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              value: _goalMissed,
+              onChanged: (v) => setState(() => _goalMissed = v),
+            ),
           ),
           const Divider(),
-          const Text('Customize Alerts'),
-          const SizedBox(height: 10),
-          DropdownButton<String>(
-            value: _reminderTime,
-            items: const [
-              DropdownMenuItem(value: '08:00', child: Text('08:00')),
-              DropdownMenuItem(value: '12:00', child: Text('12:00')),
-              DropdownMenuItem(value: '18:00', child: Text('18:00')),
-            ],
-            onChanged: (v) => setState(() => _reminderTime = v ?? '08:00'),
-            isExpanded: true,
-            hint: const Text('Reminder Time'),
+          const Padding(
+            padding: EdgeInsets.symmetric(vertical: 8),
+            child: Text(
+              'Customize Alerts',
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+            ),
           ),
-          const SizedBox(height: 10),
-          DropdownButton<String>(
-            value: _reminderHabit,
-            hint: const Text('Add habit for reminder'),
-            isExpanded: true,
-            items: _habits
-                .map((h) => DropdownMenuItem(value: h, child: Text(h)))
-                .toList(),
-            onChanged: (v) => setState(() => _reminderHabit = v),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            margin: const EdgeInsets.symmetric(vertical: 6),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(30),
+            ),
+            child: DropdownButtonHideUnderline(
+              child: DropdownButton<String>(
+                value: _reminderTime,
+                items: const [
+                  DropdownMenuItem(value: '08:00', child: Text('08:00')),
+                  DropdownMenuItem(value: '12:00', child: Text('12:00')),
+                  DropdownMenuItem(value: '18:00', child: Text('18:00')),
+                ],
+                onChanged: (v) =>
+                    setState(() => _reminderTime = v ?? '08:00'),
+                isExpanded: true,
+                hint: const Text('Reminder Time'),
+              ),
+            ),
+          ),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            margin: const EdgeInsets.symmetric(vertical: 6),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(30),
+            ),
+            child: DropdownButtonHideUnderline(
+              child: DropdownButton<String>(
+                value: _reminderHabit,
+                hint: const Text('Add habit for reminder'),
+                isExpanded: true,
+                items: _habits
+                    .map((h) => DropdownMenuItem(value: h, child: Text(h)))
+                    .toList(),
+                onChanged: (v) => setState(() => _reminderHabit = v),
+              ),
+            ),
           ),
           const SizedBox(height: 20),
-          ElevatedButton(onPressed: _save, child: const Text('Save')),
+          Center(
+            child: ElevatedButton(
+              onPressed: _save,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.purple,
+                shape: const StadiumBorder(),
+              ),
+              child: const Text(
+                'Save',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+            ),
+          ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- update background palette with vibrant colors
- redesign habit pills on home screen
- use circular Add button
- emphasize section headers and use orange accent
- refresh notifications screen with rounded toggles and dropdowns

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881560e732c832cab6e649c05743406